### PR TITLE
feat: upgrade Branch SDK version to v3.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 2.0.0 (2023-12-05)
+## Version -[2.0.0] - 2023-12-05
 
 
 ### ⚠ BREAKING CHANGES
@@ -12,3 +12,8 @@ All notable changes to this project will be documented in this file. See [standa
 ### Features
 
 * update branchSDK to 3.0.0 ([#9](https://github.com/rudderlabs/rudder-integration-branch-ios/issues/9)) ([c60f41f](https://github.com/rudderlabs/rudder-integration-branch-ios/commit/c60f41f20bcdd949360bdb47121ab1e8bd3ced20))
+
+  
+
+## Version -[2.1.0] - 2023-07-03
+* update Branch verson to 3.4.4

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @itsdebs
+* @rudderlabs/sdk-ios

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ More information on RudderStack can be found [here](https://github.com/rudderlab
 2. Rudder-Branch is available through [CocoaPods](https://cocoapods.org). To install it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Rudder-Branch'
+pod 'Rudder-Branch','~> '2.1.0'
 ```
 
 ## Initialize ```RSClient```

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
1. upgrade Branch SDK version to 3.4.4
2. we have observed deprecated method for enable logging for Branch, method is now be called using static call and depreciation is handled. 