### PR TITLE
chore: update the release version and enable option to deploy cocoapod manually

### DIFF
--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -1,6 +1,7 @@
 name: Deploy to Cocoapods
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 2.1.0 (2024-07-09)
+
+
+### Features
+
+* upgrade Branch SDK version to v3.4.4 ([#14](https://github.com/rudderlabs/rudder-integration-branch-ios/pull/14)) ([d5de3fc](https://github.com/rudderlabs/rudder-integration-branch-ios/commit/d5de3fca6c4d12a196921ed151d13c1293f7b90f))
+
 ## 2.0.0 (2023-12-05)
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ More information on RudderStack can be found [here](https://github.com/rudderlab
 2. Rudder-Branch is available through [CocoaPods](https://cocoapods.org). To install it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Rudder-Branch'
+pod 'Rudder-Branch', '~> 2.1.0'
 ```
 
 ## Initialize ```RSClient```

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
# Description

- Updated the changelog, readme and package.json pointing to the latest version.
- Added an option to trigger the `Deploy to Cocoapods` manually. This is required to release the Cocoapod manually.