### PR TITLE
chore(vuln): pin and bump action refs (SEC-171)

### DIFF
--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
       with:
         egress-policy: audit
 

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -15,7 +15,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feature/')
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/manage-github-issue-for-outdated-pods.yml
+++ b/.github/workflows/manage-github-issue-for-outdated-pods.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check outdate pods and create issue if it doesn't exist
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check outdated pods and create issue
         id: check-outdated-pods-and-create-issue
-        uses: rudderlabs/github-action-updated-pods-notifier@main
+        uses: rudderlabs/github-action-updated-pods-notifier@410c04199bc9e6d1123058bfc19e109311959ba6 # main
         with:
           outdated-pod-names: "BranchSDK"
           directory: "Example"

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -50,7 +50,7 @@ jobs:
       pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -16,7 +16,7 @@ jobs:
     if: startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 


### PR DESCRIPTION
## What

Deterministic remediation of four zizmor audit rules:

- `known-vulnerable-actions` — bumps vulnerable refs to the GHSA advisory's `first_patched_version`, re-pins to SHA, syncs the version comment.
- `unpinned-uses` — rewrites `@tag` refs to `@<sha> # <tag>`.
- `ref-version-mismatch` — rewrites the trailing comment to match the tag the pinned SHA actually points at.
- `impostor-commit` — replaces the impostor SHA with the correct SHA for the tag.

All edits are SHA-pinned ref rewrites plus comment synchronisation. No workflow logic, step ordering, permissions, or non-`.github/` files are touched.

## How

1. `zizmor --fix=all` run under a restricted config (`sec-scan/sec-ops/sec-171-action-refs/zizmor.yml`) that disables every other audit.
2. A Python post-processor (`postprocess.py`) repairs any line where zizmor's auto-fix left the ref unpinned — an observed failure mode on certain impostor-commit cases. The post-processor resolves the tag → SHA via `gh api` and rewrites the line.
3. Two sanity guards run before commit:
   - `git diff --name-only` must only contain paths under `.github/`.
   - Every added `uses:` line must match `owner/repo@<40-hex-sha>`.

## ⚠️ Merge blocker — SHA allowlist

**Do NOT merge this PR until the new SHAs have been added to the org-level GitHub action allowlist.** The rudderlabs org enforces a by-SHA allowlist on all `uses:` references (supply-chain guard). Every SHA introduced by this PR is captured in `/tmp/sec-171-sha-manifest.txt` on the machine that produced the sweep; the allowlist will be updated by @aris1009 before merge coordination.

## Ticket

Closes part of [SEC-171](https://linear.app/rudderstack/issue/SEC-171) — parent epic [SEC-162](https://linear.app/rudderstack/issue/SEC-162).
